### PR TITLE
Fix ResponseType.PAGE has wrong offset for page id.

### DIFF
--- a/nextion/client.py
+++ b/nextion/client.py
@@ -296,7 +296,7 @@ class Nextion:
                     type_ = response[0]
                     raw = response[1:]
                     if type_ == ResponseType.PAGE:  # Page ID
-                        data = raw[1]
+                        data = raw[0]
                     elif type_ == ResponseType.STRING:  # string
                         data = raw.decode(self.encoding)
                     elif type_ == ResponseType.NUMBER:  # number


### PR DESCRIPTION
Hiya,...

I noticed when trying to get the page ID, I was getting an array out of bounds exception after using the 'sendme' command.
The response from nextion when you issue this command is:

0x66 <PageID> 0xff 0xff 0xff

After stripping the Response code (0x66) raw[] is left as simply the pageID.   The _command function tries to access raw[1] which is not correct.